### PR TITLE
feat: add date picker and exora theme

### DIFF
--- a/app/_layout.js
+++ b/app/_layout.js
@@ -3,14 +3,26 @@ import { Stack } from 'expo-router';
 import { ThemeProvider, DefaultTheme } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { View } from 'react-native';
+import { useFonts, WorkSans_400Regular, WorkSans_500Medium, WorkSans_600SemiBold, WorkSans_700Bold } from '@expo-google-fonts/work-sans';
+import { colors } from '../src/theme/exora';
 
-// Layout principal con tema claro y soporte para gestos
+// Layout principal con tema claro, fuentes y soporte para gestos
 export default function RootLayout() {
+  useFonts({
+    WorkSans_400Regular,
+    WorkSans_500Medium,
+    WorkSans_600SemiBold,
+    WorkSans_700Bold,
+  });
+
   return (
-    <GestureHandlerRootView style={{ flex: 1, backgroundColor: '#f5f7fb' }}>
+    <GestureHandlerRootView style={{ flex: 1 }}>
       <ThemeProvider value={DefaultTheme}>
-        <Stack screenOptions={{ headerShown: false }} />
-        <StatusBar style="dark" />
+        <View style={{ flex: 1, backgroundColor: colors.bg }}>
+          <Stack screenOptions={{ headerShown: false }} />
+          <StatusBar style="dark" />
+        </View>
       </ThemeProvider>
     </GestureHandlerRootView>
   );

--- a/app/agenda/index.js
+++ b/app/agenda/index.js
@@ -1,35 +1,48 @@
-import React, { useState } from 'react';
-import { Text, StyleSheet, View, Dimensions } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { Text, StyleSheet, View, Dimensions, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, runOnJS } from 'react-native-reanimated';
+import dayjs from 'dayjs';
+import 'dayjs/locale/es';
 import SwipeCard from '../../components/SwipeCard';
-import { citas } from '../../lib/mockCitas';
+import DatePickerModal from '../../components/DatePickerModal';
+import EmptyState from '../../components/EmptyState';
+import { getCitasByDate } from '../../lib/mockCitas';
+import { colors, spacing, typography, radius } from '../../src/theme/exora';
 
-// Pantalla de agenda que permite navegar por las citas con gestos
+dayjs.locale('es');
+
+// Pantalla de agenda que permite navegar por las citas con gestos y selección de fecha
 export default function Agenda() {
-  const [index, setIndex] = useState(0);
+  const [selectedDateISO, setSelectedDateISO] = useState(dayjs().format('YYYY-MM-DD'));
+  const [citas, setCitas] = useState(getCitasByDate(selectedDateISO));
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [modalVisible, setModalVisible] = useState(false);
   const width = Dimensions.get('window').width;
   const translateX = useSharedValue(0);
   const opacity = useSharedValue(1);
 
-  // Cambia de cita y reinicia los valores animados
+  useEffect(() => {
+    setCitas(getCitasByDate(selectedDateISO));
+    setCurrentIndex(0);
+  }, [selectedDateISO]);
+
   const changeIndex = (next) => {
-    setIndex(next);
+    setCurrentIndex(next);
     translateX.value = 0;
     opacity.value = 1;
   };
 
-  // Maneja los gestos de swipe izquierda/derecha
   const pan = Gesture.Pan().onEnd((e) => {
-    if (e.translationX < -50 && index < citas.length - 1) {
+    if (e.translationX < -50 && currentIndex < citas.length - 1) {
       translateX.value = withTiming(-width, { duration: 200 }, (finished) => {
-        if (finished) runOnJS(changeIndex)(index + 1);
+        if (finished) runOnJS(changeIndex)(currentIndex + 1);
       });
       opacity.value = withTiming(0, { duration: 200 });
-    } else if (e.translationX > 50 && index > 0) {
+    } else if (e.translationX > 50 && currentIndex > 0) {
       translateX.value = withTiming(width, { duration: 200 }, (finished) => {
-        if (finished) runOnJS(changeIndex)(index - 1);
+        if (finished) runOnJS(changeIndex)(currentIndex - 1);
       });
       opacity.value = withTiming(0, { duration: 200 });
     } else {
@@ -42,23 +55,51 @@ export default function Agenda() {
     opacity: opacity.value,
   }));
 
-  const current = citas[index];
+  const formattedDate = dayjs(selectedDateISO).format('ddd, D MMM YYYY');
+  const current = citas[currentIndex];
+
+  const goPrev = () =>
+    setSelectedDateISO(dayjs(selectedDateISO).subtract(1, 'day').format('YYYY-MM-DD'));
+  const goNext = () =>
+    setSelectedDateISO(dayjs(selectedDateISO).add(1, 'day').format('YYYY-MM-DD'));
+  const goToday = () => setSelectedDateISO(dayjs().format('YYYY-MM-DD'));
+  const onSelectDate = (dateISO) => setSelectedDateISO(dateISO);
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.header}>
-        <Text style={styles.headerTitle}>Citas de hoy</Text>
+      <View style={styles.headerRow}>
+        <TouchableOpacity onPress={goPrev}>
+          <Text style={styles.nav}>◀︎</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => setModalVisible(true)} style={styles.chip}>
+          <Text style={styles.chipText}>{formattedDate}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={goNext}>
+          <Text style={styles.nav}>▶︎</Text>
+        </TouchableOpacity>
       </View>
-      <GestureDetector gesture={pan}>
+      <TouchableOpacity onPress={goToday} style={styles.todayButton}>
+        <Text style={styles.todayText}>Hoy</Text>
+      </TouchableOpacity>
+
+      <GestureDetector gesture={pan} enabled={citas.length > 0}>
         <Animated.View style={[styles.cardWrapper, animatedStyle]}>
-          <SwipeCard cita={current} />
+          {citas.length > 0 ? <SwipeCard cita={current} /> : <EmptyState />}
         </Animated.View>
       </GestureDetector>
-      <View style={styles.footer}>
-        <Text style={styles.footerText}>
-          {`${index + 1}/${citas.length} — Desliza izquierda/derecha`}
-        </Text>
-      </View>
+
+      {citas.length > 0 && (
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>{`${currentIndex + 1}/${citas.length} — Desliza izquierda/derecha`}</Text>
+        </View>
+      )}
+
+      <DatePickerModal
+        visible={modalVisible}
+        initialDateISO={selectedDateISO}
+        onClose={() => setModalVisible(false)}
+        onSelect={onSelectDate}
+      />
     </SafeAreaView>
   );
 }
@@ -66,28 +107,46 @@ export default function Agenda() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f7fb',
-    padding: 16,
+    backgroundColor: colors.bg,
+    padding: spacing.md,
   },
-  header: {
+  headerRow: {
+    flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 20,
+    justifyContent: 'space-between',
+    marginBottom: spacing.sm,
   },
-  headerTitle: {
-    fontSize: 24,
-    fontWeight: '600',
-    color: '#0f172a',
-    textAlign: 'center',
+  nav: {
+    ...typography.h2,
+    color: colors.text,
+  },
+  chip: {
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.md,
+    backgroundColor: colors.card,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  chipText: {
+    ...typography.label,
+  },
+  todayButton: {
+    alignSelf: 'center',
+    marginBottom: spacing.md,
+  },
+  todayText: {
+    ...typography.label,
+    color: colors.primary,
   },
   cardWrapper: {
     flex: 1,
   },
   footer: {
     alignItems: 'center',
-    marginTop: 20,
+    marginTop: spacing.md,
   },
   footerText: {
-    color: '#64748b',
-    fontSize: 14,
+    ...typography.meta,
   },
 });

--- a/components/DatePickerModal.js
+++ b/components/DatePickerModal.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Modal from 'react-native-modal';
+import { Calendar } from 'react-native-calendars';
+import { colors, typography, radius, spacing } from '../src/theme/exora';
+
+export default function DatePickerModal({ visible, initialDateISO, onClose, onSelect }) {
+  const markedDates = {
+    [initialDateISO]: { selected: true, selectedColor: colors.primary, selectedTextColor: '#ffffff' }
+  };
+
+  return (
+    <Modal isVisible={visible} onBackdropPress={onClose} style={styles.modal}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.headerText}>Selecciona una fecha</Text>
+        </View>
+        <Calendar
+          current={initialDateISO}
+          onDayPress={(day) => {
+            onSelect(day.dateString);
+            onClose();
+          }}
+          markedDates={markedDates}
+          theme={{
+            todayTextColor: colors.primary,
+            arrowColor: colors.primary,
+          }}
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modal: { margin: 0, justifyContent: 'center' },
+  container: {
+    backgroundColor: colors.card,
+    borderRadius: radius.lg,
+    marginHorizontal: spacing.md,
+    overflow: 'hidden'
+  },
+  header: {
+    backgroundColor: colors.primary,
+    padding: spacing.md,
+    alignItems: 'center'
+  },
+  headerText: {
+    ...typography.h2,
+    color: '#ffffff'
+  }
+});

--- a/components/EmptyState.js
+++ b/components/EmptyState.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors, radius, spacing, typography } from '../src/theme/exora';
+
+export default function EmptyState() {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.text}>Sin citas en esta fecha</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    backgroundColor: colors.card,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.lg,
+  },
+  text: {
+    ...typography.label,
+    color: colors.label,
+  },
+});

--- a/components/SwipeCard.js
+++ b/components/SwipeCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Linking } from 'react-native';
+import { colors, radius, spacing, typography } from '../src/theme/exora';
 
 // Tarjeta que ocupa toda la pantalla con scroll interno
 export default function SwipeCard({ cita }) {
@@ -35,7 +36,7 @@ export default function SwipeCard({ cita }) {
           style={styles.noShow}
           onPress={() => console.log('NO_SHOW', cita.id)}
         >
-          <Text style={styles.noShowText}>No se ha presentado a la cita</Text>
+          <Text style={styles.noShowText}>NO SE HA PRESENTADO A LA CITA</Text>
         </TouchableOpacity>
       </View>
     </View>
@@ -45,59 +46,53 @@ export default function SwipeCard({ cita }) {
 const styles = StyleSheet.create({
   card: {
     flex: 1,
-    backgroundColor: '#ffffff',
-    borderRadius: 18,
+    backgroundColor: colors.card,
+    borderRadius: radius.lg,
     borderWidth: 1,
-    borderColor: '#e5e7eb',
-    padding: 20,
+    borderColor: colors.border,
+    padding: spacing.lg,
   },
   content: {
-    paddingBottom: 40,
+    paddingBottom: spacing.xl,
   },
   title: {
-    fontSize: 26,
-    fontWeight: '700',
-    color: '#0f172a',
-    marginBottom: 20,
+    ...typography.h1,
     textAlign: 'center',
+    marginBottom: spacing.lg,
   },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    marginBottom: 10,
+    marginBottom: spacing.sm,
   },
   label: {
     width: 120,
-    color: '#475569',
-    fontSize: 16,
-    fontWeight: '500',
+    ...typography.label,
   },
   value: {
     flex: 1,
-    color: '#111827',
-    fontSize: 20,
-    fontWeight: '600',
+    ...typography.value,
     textAlign: 'right',
   },
   link: {
     textDecorationLine: 'underline',
+    color: colors.primary,
   },
   footer: {
-    paddingTop: 20,
+    paddingTop: spacing.lg,
   },
   noShow: {
-    backgroundColor: '#ef4444',
-    borderRadius: 12,
-    height: 52,
+    backgroundColor: colors.secondary,
+    borderRadius: radius.lg,
+    height: 56,
     alignItems: 'center',
     justifyContent: 'center',
     width: '100%',
   },
   noShowText: {
+    ...typography.label,
     color: '#ffffff',
-    fontSize: 16,
-    fontWeight: '600',
     textTransform: 'uppercase',
   },
 });

--- a/lib/mockCitas.js
+++ b/lib/mockCitas.js
@@ -1,38 +1,132 @@
-export const citas = [
-  {
-    id: 1,
-    cliente: 'Juan Pérez',
-    telefono: '600123456',
-    servicio: 'Corte de pelo',
-    variante: 'Clásico',
-    sucursal: 'Centro',
-    profesional: 'Ana Ruiz',
-    fecha: '2024-07-20',
-    hora: '09:00',
-    descuentos: '10%',
-  },
-  {
-    id: 2,
-    cliente: 'María López',
-    telefono: '600987654',
-    servicio: 'Coloración',
-    variante: 'Balayage',
-    sucursal: 'Norte',
-    profesional: 'Luis García',
-    fecha: '2024-07-20',
-    hora: '10:30',
-    descuentos: '0%',
-  },
-  {
-    id: 3,
-    cliente: 'Carlos Díaz',
-    telefono: '600555888',
-    servicio: 'Manicura',
-    variante: 'Gel',
-    sucursal: 'Sur',
-    profesional: 'Marta Pérez',
-    fecha: '2024-07-20',
-    hora: '12:00',
-    descuentos: '15%',
-  },
-];
+export const citasByDate = {
+  '2025-08-24': [
+    {
+      id: 1,
+      cliente: 'Juan Pérez',
+      telefono: '600123456',
+      servicio: 'Corte de pelo',
+      variante: 'Clásico',
+      sucursal: 'Centro',
+      profesional: 'Ana Ruiz',
+      fecha: '2025-08-24',
+      hora: '09:00',
+      descuentos: '10%'
+    },
+    {
+      id: 2,
+      cliente: 'María López',
+      telefono: '600987654',
+      servicio: 'Coloración',
+      variante: 'Balayage',
+      sucursal: 'Norte',
+      profesional: 'Luis García',
+      fecha: '2025-08-24',
+      hora: '10:30',
+      descuentos: '0%'
+    },
+    {
+      id: 3,
+      cliente: 'Carlos Díaz',
+      telefono: '600555888',
+      servicio: 'Manicura',
+      variante: 'Gel',
+      sucursal: 'Sur',
+      profesional: 'Marta Pérez',
+      fecha: '2025-08-24',
+      hora: '12:00',
+      descuentos: '15%'
+    }
+  ],
+  '2025-08-25': [
+    {
+      id: 4,
+      cliente: 'Lucía Gómez',
+      telefono: '600111222',
+      servicio: 'Pedicura',
+      variante: 'Spa',
+      sucursal: 'Centro',
+      profesional: 'Ana Ruiz',
+      fecha: '2025-08-25',
+      hora: '11:00',
+      descuentos: '5%'
+    },
+    {
+      id: 5,
+      cliente: 'Miguel Torres',
+      telefono: '600333444',
+      servicio: 'Corte de barba',
+      variante: 'Premium',
+      sucursal: 'Norte',
+      profesional: 'Luis García',
+      fecha: '2025-08-25',
+      hora: '13:30',
+      descuentos: '0%'
+    }
+  ],
+  '2025-08-26': [
+    {
+      id: 6,
+      cliente: 'Sofía Martínez',
+      telefono: '600666777',
+      servicio: 'Maquillaje',
+      variante: 'Fiesta',
+      sucursal: 'Sur',
+      profesional: 'Marta Pérez',
+      fecha: '2025-08-26',
+      hora: '08:30',
+      descuentos: '20%'
+    },
+    {
+      id: 7,
+      cliente: 'Diego Romero',
+      telefono: '600888999',
+      servicio: 'Masaje',
+      variante: 'Relajante',
+      sucursal: 'Centro',
+      profesional: 'Ana Ruiz',
+      fecha: '2025-08-26',
+      hora: '10:00',
+      descuentos: '0%'
+    },
+    {
+      id: 8,
+      cliente: 'Laura Sánchez',
+      telefono: '600444555',
+      servicio: 'Depilación',
+      variante: 'Láser',
+      sucursal: 'Norte',
+      profesional: 'Luis García',
+      fecha: '2025-08-26',
+      hora: '12:30',
+      descuentos: '10%'
+    },
+    {
+      id: 9,
+      cliente: 'Andrés Vidal',
+      telefono: '600777888',
+      servicio: 'Peinado',
+      variante: 'Boda',
+      sucursal: 'Sur',
+      profesional: 'Marta Pérez',
+      fecha: '2025-08-26',
+      hora: '15:00',
+      descuentos: '0%'
+    },
+    {
+      id: 10,
+      cliente: 'Paula Ruiz',
+      telefono: '600222333',
+      servicio: 'Tratamiento facial',
+      variante: 'Anti-edad',
+      sucursal: 'Centro',
+      profesional: 'Ana Ruiz',
+      fecha: '2025-08-26',
+      hora: '16:30',
+      descuentos: '25%'
+    }
+  ]
+};
+
+export function getCitasByDate(dateISO) {
+  return citasByDate[dateISO] || [];
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "dayjs": "^1.11.11",
+    "react-native-calendars": "^1.1308.0",
+    "react-native-modal": "^14.0.0",
+    "@expo-google-fonts/work-sans": "^0.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/theme/exora.js
+++ b/src/theme/exora.js
@@ -1,0 +1,22 @@
+export const colors = {
+  primary: '#555BF6',
+  secondary: '#FD778B',
+  comp1: '#FCFFA8',
+  comp2: '#B7F1F4',
+  comp3: '#D2E9FF',
+  dark:   '#02145C',
+  bg:     '#f5f7fb',
+  card:   '#ffffff',
+  border: '#e5e7eb',
+  text:   '#111827',
+  label:  '#475569'
+};
+export const radius = { md: 12, lg: 18 };
+export const spacing = { xs: 6, sm: 10, md: 16, lg: 20, xl: 24 };
+export const typography = {
+  h1: { fontFamily: 'WorkSans_700Bold', fontSize: 28, color: colors.text },
+  h2: { fontFamily: 'WorkSans_600SemiBold', fontSize: 22, color: colors.text },
+  label: { fontFamily: 'WorkSans_500Medium', fontSize: 16, color: colors.label },
+  value: { fontFamily: 'WorkSans_600SemiBold', fontSize: 19, color: colors.text },
+  meta: { fontFamily: 'WorkSans_500Medium', fontSize: 15, color: '#64748b' }
+};


### PR DESCRIPTION
## Summary
- add Exora brand theme with Work Sans fonts
- enable date navigation and calendar picker in agenda
- restyle agenda cards and empty state

## Testing
- `npx expo install react-native-gesture-handler react-native-reanimated` *(fails: fetch failed)*
- `npm i dayjs react-native-calendars react-native-modal` *(fails: 403 Forbidden - registry access)*
- `npm i @expo-google-fonts/work-sans expo-font` *(fails: 403 Forbidden - registry access)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unable to resolve path to module 'dayjs')*
- `npx expo start -c --tunnel` *(fails: @expo/ngrok required)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0909e368832987d88e85504c3124