### PR TITLE
chore: configure app icon

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,15 +13,15 @@
     },
     "android": {
       "adaptiveIcon": {
-        "foregroundImage": "./assets/images/adaptive-icon.png",
-        "backgroundColor": "#ffffff"
+        "foregroundImage": "./assets/images/icon.png",
+        "backgroundColor": "#FFFFFF"
       },
       "edgeToEdgeEnabled": true
     },
     "web": {
       "bundler": "metro",
       "output": "static",
-      "favicon": "./assets/images/favicon.png"
+      "favicon": "./assets/images/icon.png"
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
## Summary
- use official icon across platforms

## Testing
- `npx expo-doctor` *(fails: 403 Forbidden fetching expo-doctor package)*
- `npx expo start -c --tunnel` *(run locally and open in Expo Go)*

> To see the icon on a physical device SpringBoard, build a preview with EAS Build and distribute via TestFlight.

------
https://chatgpt.com/codex/tasks/task_e_68ab5808d25883299a1da29d32e73717