### PR TITLE
feat: redesign login screen without binary assets

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,44 +1,82 @@
 import React, { useState } from 'react';
-import { Text, TextInput, Button, StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  StyleSheet,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { StatusBar } from 'expo-status-bar';
 import { router } from 'expo-router';
 
-// Pantalla de login simple con validación de longitud > 3
+// Pantalla de login rediseñada sin recursos binarios
 export default function Login() {
   const [email, setEmail] = useState('');
-  const [code, setCode] = useState('');
-  const [error, setError] = useState('');
+  const [password, setPassword] = useState('');
+  const [remember, setRemember] = useState(false);
 
-  const handleLogin = () => {
-    if (email.length > 3 && code.length > 3) {
-      router.push('/agenda');
-    } else {
-      setError('Datos inválidos');
-    }
+  const emailRegex = /^.+@.+\..+$/;
+  const isValid = emailRegex.test(email) && password.length >= 4;
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+    router.push('/agenda'); // TODO: conectar con API real
   };
 
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Agenda Exora</Text>
-      <TextInput
-        style={styles.input}
-        placeholder="Email"
-        placeholderTextColor="#9ca3af"
-        value={email}
-        onChangeText={setEmail}
-        keyboardType="email-address"
-        autoCapitalize="none"
-      />
-      <TextInput
-        style={styles.input}
-        placeholder="Código"
-        placeholderTextColor="#9ca3af"
-        value={code}
-        onChangeText={setCode}
-        secureTextEntry
-      />
-      {error ? <Text style={styles.error}>{error}</Text> : null}
-      <Button title="Entrar" onPress={handleLogin} />
+      <StatusBar style="light" />
+      <LinearGradient
+        colors={["#555BF6", "#6A67F7"]}
+        start={{ x: 0, y: 0.2 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.header}
+      >
+        <View style={styles.brandMark}>
+          <View style={styles.quarterCircle} />
+          <View style={styles.coralDot} />
+        </View>
+        <Text style={styles.title}>Inicia sesión</Text>
+      </LinearGradient>
+
+      <View style={styles.form}>
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          placeholderTextColor="rgba(17,24,39,0.35)"
+          autoCapitalize="none"
+          keyboardType="email-address"
+          value={email}
+          onChangeText={setEmail}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Contraseña"
+          placeholderTextColor="rgba(17,24,39,0.35)"
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+        />
+        <Pressable
+          onPress={() => setRemember(!remember)}
+          style={styles.rememberRow}
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: remember }}
+          hitSlop={8}
+        >
+          <View style={[styles.checkbox, remember && styles.checkboxChecked]} />
+          <Text style={styles.rememberText}>Recordarme</Text>
+        </Pressable>
+        <Pressable
+          onPress={handleSubmit}
+          disabled={!isValid}
+          style={[styles.button, !isValid && styles.buttonDisabled]}
+        >
+          <Text style={styles.buttonText}>Entrar</Text>
+        </Pressable>
+      </View>
     </SafeAreaView>
   );
 }
@@ -47,27 +85,98 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#f5f7fb',
-    padding: 16,
-    justifyContent: 'center',
+  },
+  header: {
+    height: '45%',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    paddingBottom: 32,
+  },
+  brandMark: {
+    position: 'relative',
+    width: 60,
+    height: 60,
+    marginBottom: 16,
+  },
+  quarterCircle: {
+    width: 60,
+    height: 60,
+    backgroundColor: '#FFFFFF',
+    borderTopLeftRadius: 60,
+    transform: [{ rotate: '270deg' }],
+  },
+  coralDot: {
+    position: 'absolute',
+    width: 14,
+    height: 14,
+    backgroundColor: '#FD778B',
+    borderRadius: 7,
+    top: -7,
+    right: -7,
   },
   title: {
-    color: '#111827',
-    fontSize: 24,
-    marginBottom: 24,
+    color: '#FFFFFF',
+    fontSize: 30,
+    fontWeight: '700',
     textAlign: 'center',
+  },
+  form: {
+    paddingHorizontal: 24,
+    marginTop: -24,
   },
   input: {
-    backgroundColor: '#ffffff',
-    color: '#111827',
-    padding: 12,
-    borderRadius: 8,
+    backgroundColor: '#FFFFFF',
+    height: 56,
+    paddingHorizontal: 18,
+    borderRadius: 28,
     borderWidth: 1,
-    borderColor: '#e5e7eb',
-    marginBottom: 12,
+    borderColor: '#E5E7EB',
+    marginBottom: 16,
+    fontSize: 16,
+    color: '#111827',
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 2,
   },
-  error: {
-    color: 'red',
-    marginBottom: 12,
-    textAlign: 'center',
+  rememberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 24,
+    paddingVertical: 11,
+  },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 4,
+    marginRight: 8,
+    backgroundColor: 'transparent',
+  },
+  checkboxChecked: {
+    backgroundColor: '#555BF6',
+  },
+  rememberText: {
+    fontSize: 16,
+    color: '#334155',
+    fontWeight: '600',
+  },
+  button: {
+    height: 54,
+    borderRadius: 28,
+    backgroundColor: '#555BF6',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 18,
+    fontWeight: '600',
   },
 });
+

--- a/assets/images/README.md
+++ b/assets/images/README.md
@@ -1,0 +1,11 @@
+# Login mark
+
+La marca del header del login se construyó únicamente con componentes `View` y gradientes, sin usar archivos binarios.
+
+Si en el futuro se desea usar un PNG o SVG, colócalo en `./assets/images/logo-mark.png` y reemplaza el bloque de `View` por:
+
+```jsx
+<Image source={require('../../assets/images/logo-mark.png')} style={{ width: 60, height: 60 }} />
+```
+
+(No incluir el binario en el repositorio).

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-image": "~2.4.0",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.5",
+    "expo-linear-gradient": "~14.0.1",
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",


### PR DESCRIPTION
## Summary
- redesign login screen with gradient header, geometric brand and minimal form
- add expo-linear-gradient dependency
- document future logo placement without binary assets

## Testing
- `npx expo install expo-linear-gradient` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab7b9547748329995ddce32ff3ddbb