### PR TITLE
chore: force login entry and new slug

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "agenda-exora",
-    "slug": "agenda-exora",
+    "name": "Agenda Exora Dev",
+    "slug": "agenda-exora-dev",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",

--- a/app/_layout.js
+++ b/app/_layout.js
@@ -12,4 +12,3 @@ export default function RootLayout() {
     </GestureHandlerRootView>
   );
 }
-

--- a/app/index.js
+++ b/app/index.js
@@ -1,2 +1,1 @@
 export { default } from './login';
-

--- a/app/login.js
+++ b/app/login.js
@@ -1,16 +1,5 @@
-import React, { useState, useRef } from 'react';
-import {
-  SafeAreaView,
-  Image,
-  Text,
-  TextInput,
-  View,
-  Pressable,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-} from 'react-native';
-import { StatusBar } from 'expo-status-bar';
+import React, { useState } from 'react';
+import { SafeAreaView, Image, Text, TextInput, View, Pressable } from 'react-native';
 import { useRouter } from 'expo-router';
 
 export default function Login() {
@@ -18,19 +7,16 @@ export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [remember, setRemember] = useState(false);
-  const passwordRef = useRef(null);
 
   const emailValid = /.+@.+\..+/.test(email);
   const passwordValid = password.length >= 4;
   const canSubmit = emailValid && passwordValid;
 
   const onSubmit = () => {
-    if (!canSubmit) return;
-    router.push('/agenda');
+    if (canSubmit) {
+      router.push('/agenda');
+    }
   };
-
-  const showEmailError = email.length > 0 && !emailValid;
-  const showPasswordError = password.length > 0 && !passwordValid;
 
   return (
     <SafeAreaView
@@ -39,164 +25,99 @@ export default function Login() {
         backgroundColor: '#555BF6',
         alignItems: 'center',
         justifyContent: 'center',
-        paddingHorizontal: 20,
+        padding: 20,
       }}
     >
-      <StatusBar style="light" />
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        style={{ flex: 1, width: '100%' }}
+      <Image
+        source={require('../assets/images/logo-mark.png')}
+        style={{ width: 128, height: 128, marginBottom: 24 }}
+      />
+      <Text
+        style={{
+          color: '#fff',
+          fontSize: 24,
+          fontWeight: '700',
+          marginBottom: 20,
+        }}
       >
-        <ScrollView
-          contentContainerStyle={{
-            flexGrow: 1,
-            alignItems: 'center',
-            justifyContent: 'center',
+        Inicia sesión
+      </Text>
+      <TextInput
+        value={email}
+        onChangeText={setEmail}
+        placeholder="Email"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        style={{
+          width: '100%',
+          maxWidth: 320,
+          backgroundColor: '#fff',
+          borderRadius: 8,
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+          marginBottom: 12,
+        }}
+      />
+      <TextInput
+        value={password}
+        onChangeText={setPassword}
+        placeholder="Contraseña"
+        secureTextEntry
+        style={{
+          width: '100%',
+          maxWidth: 320,
+          backgroundColor: '#fff',
+          borderRadius: 8,
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+          marginBottom: 16,
+        }}
+      />
+      <Pressable
+        onPress={() => setRemember(!remember)}
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          alignSelf: 'flex-start',
+          marginBottom: 16,
+          maxWidth: 320,
+        }}
+      >
+        <View
+          style={{
+            width: 20,
+            height: 20,
+            borderWidth: 1,
+            borderColor: '#fff',
+            backgroundColor: remember ? '#fff' : 'transparent',
+            marginRight: 8,
           }}
-          keyboardShouldPersistTaps="handled"
+        />
+        <Text style={{ color: '#fff' }}>Recordarme</Text>
+      </Pressable>
+      <Pressable
+        onPress={onSubmit}
+        disabled={!canSubmit}
+        style={{
+          width: '100%',
+          maxWidth: 320,
+          backgroundColor: '#fff',
+          borderRadius: 8,
+          paddingVertical: 12,
+          alignItems: 'center',
+          opacity: canSubmit ? 1 : 0.5,
+        }}
+      >
+        <Text
+          style={{
+            color: '#555BF6',
+            fontSize: 16,
+            fontWeight: '600',
+          }}
         >
-          <Image
-            source={require('../assets/images/logo-mark.png')}
-            style={{
-              width: 128,
-              height: 128,
-              resizeMode: 'contain',
-              marginBottom: 16,
-            }}
-          />
-          <Text
-            style={{
-              color: '#fff',
-              fontSize: 24,
-              lineHeight: 24,
-              fontWeight: '700',
-              textAlign: 'center',
-              marginBottom: 20,
-            }}
-          >
-            Inicia sesión
-          </Text>
-
-          <View
-            style={{
-              width: '100%',
-              maxWidth: 420,
-            }}
-          >
-            <View
-              style={{
-                backgroundColor: '#fff',
-                borderRadius: 20,
-                padding: 18,
-                shadowColor: '#000',
-                shadowOffset: { width: 0, height: 1 },
-                shadowOpacity: 0.05,
-                shadowRadius: 4,
-                elevation: 2,
-              }}
-            >
-              <TextInput
-                placeholder="tu@correo.com"
-                keyboardType="email-address"
-                autoCapitalize="none"
-                value={email}
-                onChangeText={setEmail}
-                returnKeyType="next"
-                onSubmitEditing={() => passwordRef.current?.focus()}
-                style={{
-                  height: 52,
-                  borderRadius: 28,
-                  borderWidth: 1,
-                  borderColor: '#E5E7EB',
-                  paddingHorizontal: 18,
-                  color: '#111827',
-                  marginBottom: showEmailError ? 4 : 16,
-                }}
-              />
-              {showEmailError && (
-                <Text style={{ color: '#EF4444', fontSize: 12, marginBottom: 12 }}>
-                  Email inválido
-                </Text>
-              )}
-              <TextInput
-                ref={passwordRef}
-                placeholder="••••••••"
-                secureTextEntry
-                value={password}
-                onChangeText={setPassword}
-                returnKeyType="done"
-                onSubmitEditing={onSubmit}
-                style={{
-                  height: 52,
-                  borderRadius: 28,
-                  borderWidth: 1,
-                  borderColor: '#E5E7EB',
-                  paddingHorizontal: 18,
-                  color: '#111827',
-                  marginBottom: showPasswordError ? 4 : 0,
-                }}
-              />
-              {showPasswordError && (
-                <Text style={{ color: '#EF4444', fontSize: 12, marginTop: 4 }}>
-                  Mínimo 4 caracteres
-                </Text>
-              )}
-            </View>
-
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                marginTop: 16,
-                marginBottom: 16,
-              }}
-            >
-              <Pressable
-                onPress={() => setRemember(!remember)}
-                hitSlop={10}
-                style={{
-                  width: 22,
-                  height: 22,
-                  borderRadius: 4,
-                  borderWidth: 1,
-                  borderColor: remember ? '#fff' : '#E5E7EB',
-                  backgroundColor: remember ? '#fff' : 'transparent',
-                  marginRight: 8,
-                }}
-              />
-              <Text
-                style={{ color: '#fff', fontSize: 16, fontWeight: '600' }}
-              >
-                Recordarme
-              </Text>
-            </View>
-
-            <Pressable
-              onPress={onSubmit}
-              disabled={!canSubmit}
-              style={{
-                height: 52,
-                borderRadius: 28,
-                backgroundColor: '#fff',
-                alignItems: 'center',
-                justifyContent: 'center',
-                opacity: canSubmit ? 1 : 0.5,
-              }}
-            >
-              <Text
-                style={{
-                  color: '#555BF6',
-                  fontSize: 18,
-                  fontWeight: '600',
-                }}
-              >
-                Entrar
-              </Text>
-            </Pressable>
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+          Entrar
+        </Text>
+      </Pressable>
     </SafeAreaView>
   );
 }
-


### PR DESCRIPTION
## Summary
- ensure root route loads login screen
- implement minimal login UI with basic validation and navigation to agenda
- update Expo slug and name to refresh project

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: expo: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo-linear-gradient)*

------
https://chatgpt.com/codex/tasks/task_e_68abae289ed08329bcc1a4f3fd17d0d8